### PR TITLE
fix: silence httpx/httpcore INFO logs that leak bot token in URL

### DIFF
--- a/wachter/actions.py
+++ b/wachter/actions.py
@@ -16,6 +16,11 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     level=logging.INFO,
 )
+# httpx/httpcore логируют каждый HTTP-запрос на уровне INFO, включая URL с токеном
+# бота (например, getUpdates раз в ~10 сек при long-polling). Поднимаем порог до
+# WARNING: шум уходит, токен в логи не попадает, реальные ошибки HTTP остаются видны.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 # Счётчик попыток /whois от не-админов: user_id → (количество, время_последней_попытки)


### PR DESCRIPTION
httpx logged every getUpdates request at INFO level, including the full Telegram API URL which contains the bot token. Raise httpx/httpcore log level to WARNING: removes the polling noise and the token from logs while keeping real HTTP errors visible.