### PR TITLE
fix(dashboard): bind gunicorn to $PORT for Railway (was hardcoded 800…

### DIFF
--- a/nes_directory/Dockerfile
+++ b/nes_directory/Dockerfile
@@ -14,6 +14,6 @@ COPY templates ./templates
 
 EXPOSE 8000
 
-# single worker on purpose: the scheduler thread + file lock assume one process
-CMD ["gunicorn", "-w", "1", "--threads", "8", "-b", "0.0.0.0:8000", \
-     "--timeout", "120", "app:app"]
+# single worker on purpose: the scheduler thread + file lock assume one process.
+# shell-form CMD so ${PORT} (injected by Railway) expands; fallback 8000 locally.
+CMD gunicorn -w 1 --threads 8 -b "0.0.0.0:${PORT:-8000}" --timeout 120 app:app


### PR DESCRIPTION
…0 → 502)

Railway injects $PORT and routes to it; the exec-form CMD hardcoded 8000 so the proxy hit the wrong port (502). Shell-form CMD expands ${PORT:-8000} — Railway uses its port, local docker-compose still falls back to 8000.