### PR TITLE
fix(dashboard): ensure schema on startup so a fresh deploy shows empt…

### DIFF
--- a/nes_directory/app.py
+++ b/nes_directory/app.py
@@ -457,6 +457,13 @@ def identity_category(user_id):
     return redirect(url_for("identity_detail", user_id=user_id))
 
 
+# создаём общую схему (alumni_* / tg_identity) на старте, чтобы свежий деплой
+# показывал пустое состояние, а не 500 до первого bootstrap. Идемпотентно.
+try:
+    am.init_db()
+except Exception as e:
+    print(f"[startup] init_db пропущен: {e}")
+
 start_scheduler_once()
 
 if __name__ == "__main__":


### PR DESCRIPTION
…y, not 500

The index page queries alumni_person immediately; on a freshly-provisioned Postgres (before bootstrap) the table doesn't exist → 500. Call init_db() at startup (idempotent create_all, wrapped in try/except) so the dashboard renders an empty state; bootstrap.py then fills the data.